### PR TITLE
fix: chang to exit instead of close 

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,8 +76,8 @@ module.exports = function runScript(script, options, extraOptions) {
       reject(err);
     });
 
-    proc.on('close', code => {
-      debug('proc emit close: %s', code);
+    proc.on('exit', code => {
+      debug('proc emit exit: %s', code);
       if (isEnd) return;
       isEnd = true;
       clearTimeout(timeoutTimer);
@@ -102,8 +102,8 @@ module.exports = function runScript(script, options, extraOptions) {
       return resolve(stdio);
     });
 
-    proc.on('exit', code => {
-      debug('proc emit exit: %s', code);
+    proc.on('close', code => {
+      debug('proc emit close: %s', code);
     });
 
     if (typeof extraOptions.timeout === 'number' && extraOptions.timeout > 0) {

--- a/test/fixtures/child-process-with-unclosed-stdio.js
+++ b/test/fixtures/child-process-with-unclosed-stdio.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const path = require('path');
+const runScript = require('../../');
+const argv = process.argv.slice(2);
+
+(async () => {
+  if (argv[0] === undefined) {
+    runScript(`node ${path.join(__dirname, './child-process-with-unclosed-stdio.js')} child`);
+    await new Promise(resolve => {
+      setTimeout(resolve, 1000);
+    });
+    console.log('child finish');
+    process.exit();
+  } else if (argv[0] === 'child') {
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      console.log('grandChild running');
+      await new Promise(resolve => {
+        setTimeout(resolve, 1000);
+      });
+    }
+  }
+})();

--- a/test/runscript.test.js
+++ b/test/runscript.test.js
@@ -170,7 +170,7 @@ describe('runscript.test.js', () => {
     });
   });
 
-  it.only('should exit when child process has not closed stdio streams', () => {
+  it('should exit when child process has not closed stdio streams', () => {
     return runScript(`node ${path.join(__dirname, 'fixtures/child-process-with-unclosed-stdio.js')}`, {
       stdio: 'pipe',
     }).then(stdio => {

--- a/test/runscript.test.js
+++ b/test/runscript.test.js
@@ -170,6 +170,14 @@ describe('runscript.test.js', () => {
     });
   });
 
+  it.only('should exit when child process has not closed stdio streams', () => {
+    return runScript(`node ${path.join(__dirname, 'fixtures/child-process-with-unclosed-stdio.js')}`, {
+      stdio: 'pipe',
+    }).then(stdio => {
+      assert(/child finish/.test(stdio.stdout.toString().trim()));
+    });
+  });
+
   if (process.platform === 'win32') {
     it('should run relative path .\\node_modules\\.bin\\autod', () => {
       return runScript('.\\node_modules\\.bin\\autod -V', {


### PR DESCRIPTION
base on nodejs doc:
```
Event: 'close'
Added in: v0.7.7
code [<number>] The exit code if the child exited on its own.
signal [<string>] The signal by which the child process was terminated.
The 'close' event is emitted after a process has ended and the stdio streams of a child process have been closed. This is distinct from the ['exit'](https://nodejs.org/api/child_process.html#event-exit) event, since multiple processes might share the same stdio streams. The 'close' event will always emit after ['exit'](https://nodejs.org/api/child_process.html#event-exit) was already emitted, or ['error'](https://nodejs.org/api/child_process.html#event-error) if the child failed to spawn.
```

if child process has unclosed stdio，then the main process cannot resolve successfully。

