### PR TITLE
feat: use object.assign instead of object.create

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = function runScript(script, options, extraOptions) {
   return new Promise((resolve, reject) => {
     extraOptions = extraOptions || {};
     options = options || {};
-    options.env = options.env || Object.create(process.env);
+    options.env = options.env || Object.assign({}, process.env);
     options.cwd = options.cwd || process.cwd();
     options.stdio = options.stdio || 'inherit';
     if (options.stdout) assert(is.writableStream(options.stdout), 'options.stdout should be writable stream');


### PR DESCRIPTION
with node v14 ，use object.create will cause set process.env failed。

v14.19.1
![image](https://user-images.githubusercontent.com/8433821/169344194-2a07b8ee-51c5-499c-9d1b-82c96b29fead.png)

v12.15.0
![image](https://user-images.githubusercontent.com/8433821/169344250-15a46b48-d14f-4905-9ad8-c200b979c5cd.png)
